### PR TITLE
Add copy to clipboard button on item listings

### DIFF
--- a/src/arevtur/DataFetcher.js
+++ b/src/arevtur/DataFetcher.js
@@ -277,7 +277,8 @@ class QueryParams {
 			defenses: QueryParams.evalDefensePropertiesValue(defenseProperties, this.defenseProperties),
 			mods: QueryParams.evalValue(pseudoMods),
 		};
-		let valueBuild = itemEval?.evalItem(ItemEval.decode64(itemData.item.extended.text)) || Promise.resolve('');
+		let text = ItemEval.decode64(itemData.item.extended.text);
+		let valueBuild = itemEval?.evalItem(text) || Promise.resolve('');
 		let priceDetails = {
 			count: itemData.listing.price.amount,
 			currency: itemData.listing.price.currency,
@@ -308,6 +309,7 @@ class QueryParams {
 			valueBuild,
 			evalPrice: await QueryParams.evalPrice(this.league, priceDetails),
 			priceDetails,
+			text,
 			debug: itemData,
 		};
 	}

--- a/src/arevtur/xElements/itemListing/ItemListing.html
+++ b/src/arevtur/xElements/itemListing/ItemListing.html
@@ -112,7 +112,7 @@
 	<div>
 		<span class="value">Value: <span id="value-text"></span></span>
 		<span id="value-build-link" class="hidden">(build)<span id="value-build-tooltip"></span></span>
-		<button id="copy-item-button">Copy to Clipboard</button>
+		<button id="copy-item-button">Copy item</button>
 	</div>
 	<div id="value-expanded-text" class="expanded"></div>
 	<div class="price">Price: <span id="price-text"></span> chaos</div>

--- a/src/arevtur/xElements/itemListing/ItemListing.html
+++ b/src/arevtur/xElements/itemListing/ItemListing.html
@@ -112,6 +112,7 @@
 	<div>
 		<span class="value">Value: <span id="value-text"></span></span>
 		<span id="value-build-link" class="hidden">(build)<span id="value-build-tooltip"></span></span>
+		<button id="copy-item-button">Copy to Clipboard</button>
 	</div>
 	<div id="value-expanded-text" class="expanded"></div>
 	<div class="price">Price: <span id="price-text"></span> chaos</div>

--- a/src/arevtur/xElements/itemListing/ItemListing.js
+++ b/src/arevtur/xElements/itemListing/ItemListing.js
@@ -33,7 +33,7 @@ customElements.define(name, class extends XElement {
 				navigator.clipboard.writeText(valueBuild);
 			});
 			e.stopPropagation();
-		})
+		});
 		this.$('#whisper-button').addEventListener('click', e => {
 			navigator.clipboard.writeText(this.itemData_.whisper);
 			e.stopPropagation();

--- a/src/arevtur/xElements/itemListing/ItemListing.js
+++ b/src/arevtur/xElements/itemListing/ItemListing.js
@@ -28,10 +28,7 @@ customElements.define(name, class extends XElement {
 
 	connectedCallback() {
 		this.$('#copy-item-button').addEventListener('click', e => {
-			this.itemData_.valueBuild.then(valueBuild => {
-				valueBuild = valueBuild.substring(0, valueBuild.indexOf('Note:'));
-				navigator.clipboard.writeText(valueBuild);
-			});
+			navigator.clipboard.writeText(this.itemData_.text);
 			e.stopPropagation();
 		});
 		this.$('#whisper-button').addEventListener('click', e => {

--- a/src/arevtur/xElements/itemListing/ItemListing.js
+++ b/src/arevtur/xElements/itemListing/ItemListing.js
@@ -31,6 +31,13 @@ customElements.define(name, class extends XElement {
 			navigator.clipboard.writeText(this.itemData_.whisper);
 			e.stopPropagation();
 		});
+		this.$('#copy-item-button').addEventListener('click', e => {
+			this.itemData_.valueBuild.then(valueBuild => {
+				valueBuild = valueBuild.substring(0, valueBuild.indexOf('Note:'));
+				navigator.clipboard.writeText(valueBuild);
+			})
+			e.stopPropagation();
+		})
 		this.addEventListener('click', () => this.emit('select'));
 		this.addEventListener('mouseenter', () => {
 			if (!this.hovered)

--- a/src/arevtur/xElements/itemListing/ItemListing.js
+++ b/src/arevtur/xElements/itemListing/ItemListing.js
@@ -31,7 +31,7 @@ customElements.define(name, class extends XElement {
 			this.itemData_.valueBuild.then(valueBuild => {
 				valueBuild = valueBuild.substring(0, valueBuild.indexOf('Note:'));
 				navigator.clipboard.writeText(valueBuild);
-			})
+			});
 			e.stopPropagation();
 		})
 		this.$('#whisper-button').addEventListener('click', e => {

--- a/src/arevtur/xElements/itemListing/ItemListing.js
+++ b/src/arevtur/xElements/itemListing/ItemListing.js
@@ -27,10 +27,6 @@ customElements.define(name, class extends XElement {
 	}
 
 	connectedCallback() {
-		this.$('#whisper-button').addEventListener('click', e => {
-			navigator.clipboard.writeText(this.itemData_.whisper);
-			e.stopPropagation();
-		});
 		this.$('#copy-item-button').addEventListener('click', e => {
 			this.itemData_.valueBuild.then(valueBuild => {
 				valueBuild = valueBuild.substring(0, valueBuild.indexOf('Note:'));
@@ -38,6 +34,10 @@ customElements.define(name, class extends XElement {
 			})
 			e.stopPropagation();
 		})
+		this.$('#whisper-button').addEventListener('click', e => {
+			navigator.clipboard.writeText(this.itemData_.whisper);
+			e.stopPropagation();
+		});
 		this.addEventListener('click', () => this.emit('select'));
 		this.addEventListener('mouseenter', () => {
 			if (!this.hovered)


### PR DESCRIPTION
Created a copy to clipboard button so people can plug the items back into PoB easily to evaluate and continue to craft on an item they like. Sorry if this is already in somewhere ... I couldn't find it. Best I fund was hovering over the (build) button which was sometimes unreliable as a copy-paste window.